### PR TITLE
fix　入力が閉じられた際の無限ループの問題を修正

### DIFF
--- a/cpp00/ex01/PhoneBook.cpp
+++ b/cpp00/ex01/PhoneBook.cpp
@@ -58,6 +58,8 @@ void PhoneBook::init_phonebook()
 	std::string input_command;
 	while (1)
 	{
+		if(std::cin.eof())// Ctrl-Dが押されたか判定　　これがないと入力が閉じられた時に無限ループしてしまう
+			std::exit(1); //理想はmainでexitすると良い　クラス内の場合デストラクタを呼び出さずに処理を終了するため
 		std::cout << "Please enter ADD, SEARCH, or EXIT: ";
 		getline(std::cin, input_command);
 		if (input_command == "ADD")


### PR DESCRIPTION
・Ctrl-D が入力されると、以降は std::cin から読み込みができなくなってしまう。
そのためexitで無限ループ回避

・exitはmain関数で使えたら理想（今はクラス内で使っているが）
そのクラスのデストラクタをフル無視してexitしてしまうため良くない